### PR TITLE
Bug fixed unrecognized symbols

### DIFF
--- a/Calculator/mainwindow.cpp
+++ b/Calculator/mainwindow.cpp
@@ -1,11 +1,5 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
-#include <QDebug>
-#include <iostream>
-#define FACTORIAL_INFINITY 15000
-#define RAD 57.2957795
-#define PI 3.14159265358979323
-#define GRAD 63.661977237
 double firstNum;
 bool user_is_typing_secondNumber=false;
 double answer=0;

--- a/Calculator/mainwindow.h
+++ b/Calculator/mainwindow.h
@@ -2,7 +2,13 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-
+#include <math.h>
+#include <QDebug>
+#include <iostream>
+#define FACTORIAL_INFINITY 15000
+#define RAD 57.2957795
+#define PI 3.14159265358979323
+#define GRAD 63.661977237
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE


### PR DESCRIPTION
- Fixed a bug where all the mathematical functions were not recognized by the compiler. This was solved by adding 
```C++
#include<math.h>
```
at the start of the header file.
- Moved all the includes and difines to the header file.